### PR TITLE
Feat(TP41-274):  Connectors - Abstract policy generation and validation

### DIFF
--- a/src/main/java/org/factoryx/library/connector/embedded/provider/controller/DspCatalogController.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/controller/DspCatalogController.java
@@ -62,14 +62,14 @@ public class DspCatalogController {
 
         try {
             log.info("Starting token validation");
-            String result = dspTokenValidationService.validateToken(token);
-            log.info("Got Result from token validation: {}", result);
-            if (result == null) {
+            String partnerId = dspTokenValidationService.validateToken(token);
+            log.info("Got Result from token validation: {}", partnerId);
+            if (partnerId == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
-            List<JsonObject> catalogs = dspCatalogService.getAllCatalogs();
-            JsonObject jsonResponse = dspCatalogService.buildFinalCatalogResponse(catalogs);
+            JsonObject jsonResponse = dspCatalogService.getFullCatalog(partnerId);
             return ResponseEntity.status(HttpStatus.OK).body(jsonResponse.toString());
+
         } catch (Exception e) {
             // Handle any unexpected errors
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred while processing the request.");

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DspPolicyService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DspPolicyService.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2024. Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.factoryx.library.connector.embedded.provider.interfaces;
+
+import com.apicatalog.jsonld.JsonLd;
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.factoryx.library.connector.embedded.provider.service.helpers.EnvService;
+
+import static org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils.DSPACE_NAMESPACE;
+import static org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils.ODRL_NAMESPACE;
+
+/**
+ * This abstract class provides the interface for the DspPolicyService.
+ * <p>
+ * The customization for the requirements of a concrete dataspace can be done
+ * by overriding the getPermission, getProhibition and getObligation methods.
+ *
+ */
+public abstract class DspPolicyService {
+
+    protected final EnvService envService;
+
+    protected static final String ID = "@id";
+
+    protected DspPolicyService(EnvService envService) {
+        this.envService = envService;
+    }
+
+    // public interface methods:
+
+    /**
+     * This method returns an odrl:Offer typed object with the following structure:
+     * <p>
+     * {
+     * <p>
+     *     "@type": "odrl:Offer",
+     * <p>
+     *     "odrl:permission": [ ... ],
+     * <p>
+     *     "odrl:prohibition": [ ... ],
+     * <p>
+     *     "odrl:obligation": [ ... ],
+     * <p>
+     *     "odrl:assignee": "<string>",
+     * <p>
+     *     "odrl:assigner": "<string>",
+     * <p>
+     *     "odrl:target":
+     *     <p>
+     *                      {
+     *                      <p>
+     *                          "@id" : "<string"
+     *                          <p>
+     *                      }
+     * <p>
+     * }
+     * <p>
+     *
+     * Note that you can and should provide customized implementations of the getPermission, getProhibition
+     * and getObligation methods as required by the framework agreements of the dataspace you want to participate in.
+     *
+     * @param assetId the id of the asset in question
+     * @param partnerId the id of the partner who is interested in the given asset
+     * @return the JSON object
+     */
+    public final JsonObject createOfferedPolicy(String assetId, String partnerId) {
+        return Json.createObjectBuilder()
+                .add("@type", "odrl:Offer")
+                .add("odrl:permission", getPermission(assetId, partnerId))
+                .add("odrl:prohibition", getProhibition(assetId, partnerId))
+                .add("odrl:obligation", getObligation(assetId, partnerId))
+                .add("odrl:assigner", envService.getBackendId())
+                .add("odrl:assignee", partnerId)
+                .add("odrl:target", Json.createObjectBuilder().add(ID, assetId).build())
+                .build();
+    }
+
+    public JsonValue getPermission(String assetId, String partnerId) {
+        return JsonValue.EMPTY_JSON_ARRAY;
+    }
+
+    public JsonValue getProhibition(String assetId, String partnerId) {
+        return JsonValue.EMPTY_JSON_ARRAY;
+    }
+
+    public JsonValue getObligation(String assetId, String partnerId) {
+        return JsonValue.EMPTY_JSON_ARRAY;
+    }
+
+    /**
+     * This method expects an offer object from a new negotiation request and checks if
+     * the given object matches the expected content.
+     *
+     *
+     * @param offer the offer object
+     * @param targetAssetId the target asset id
+     * @param partnerId the id of the negotiation partner
+     * @return true if the offer is valid.
+     */
+    public final boolean validateOffer(JsonObject offer, String targetAssetId, String partnerId) {
+        try {
+            JsonObject offerObject = removeId(offer);
+            JsonObject expectedObject = createExpandedPolicy(targetAssetId, partnerId);
+            return offerObject.equals(expectedObject);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    // helper methods:
+
+    /**
+     * When comparing an offer to an expected counterpart, the "@id" values are not required to match.
+     * Therefore, we remove it before comparing.
+     *
+     * @param offer an offer received from a negotiation partner
+     * @return the same object, but without an "@id" field
+     */
+    private JsonObject removeId(JsonObject offer) {
+        var offerBuilder = Json.createObjectBuilder(offer);
+        offerBuilder.remove(ID);
+        return offerBuilder.build();
+    }
+
+    /**
+     * Since the negotiation request from a partner is expanded, we need to expand
+     * our own comparison object as well.
+     *
+     * @param targetAssetId the id of the asset in question
+     * @param partnerId the id of the negotiation partner
+     * @return the expanded object that can be compared with the partner's offer
+     */
+    private JsonObject createExpandedPolicy(String targetAssetId, String partnerId) {
+        try {
+            var wrapper = Json.createObjectBuilder();
+            var odrlContext = Json.createObjectBuilder()
+                    .add("@vocab", ODRL_NAMESPACE)
+                    .add("dspace", DSPACE_NAMESPACE)
+                    .add("odrl", ODRL_NAMESPACE);
+            wrapper.add("@context", odrlContext.build());
+            wrapper.add("dspace:Offer", createOfferedPolicy(targetAssetId, partnerId));
+            return JsonLd.expand(JsonDocument.of(wrapper.build()))
+                    .get()
+                    .getJsonObject(0)
+                    .getJsonArray(DSPACE_NAMESPACE + "Offer")
+                    .getJsonObject(0);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/model/negotiation/NegotiationRecord.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/model/negotiation/NegotiationRecord.java
@@ -84,16 +84,6 @@ public class NegotiationRecord {
      */
     private UUID contractId;
 
-    /**
-     * The following attributes store the terms of the contract.
-     */
-    @Column(length = 5000)
-    private String permissions;
-    @Column(length = 5000)
-    private String obligations;
-    @Column(length = 5000)
-    private String prohibitions;
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspCatalogService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspCatalogService.java
@@ -20,6 +20,7 @@ import jakarta.json.*;
 import lombok.extern.slf4j.Slf4j;
 import org.factoryx.library.connector.embedded.provider.interfaces.DataAsset;
 import org.factoryx.library.connector.embedded.provider.interfaces.DataAssetManagementService;
+import org.factoryx.library.connector.embedded.provider.interfaces.DspPolicyService;
 import org.factoryx.library.connector.embedded.provider.service.helpers.EnvService;
 import org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,15 +43,7 @@ public class DspCatalogService {
 
     private final EnvService envService;
 
-    public static final JsonArray EMPTY_ARRAY = Json.createArrayBuilder().build();
-
-    public static final JsonObject POLICY = Json.createObjectBuilder()
-            .add("@id", UUID.randomUUID().toString())
-            .add("@type", "odrl:Offer")
-            .add("odrl:permission", EMPTY_ARRAY)
-            .add("odrl:prohibition", EMPTY_ARRAY)
-            .add("odrl:obligation", EMPTY_ARRAY)
-            .build();
+    private final DspPolicyService policyService;
 
     /**
      * Constructor for injecting the DataManagementService and EnvService.
@@ -59,9 +52,10 @@ public class DspCatalogService {
      * @param envService the EnvService to be injected
      */
     @Autowired
-    public DspCatalogService(DataAssetManagementService dataManagementService, EnvService envService) {
+    public DspCatalogService(DataAssetManagementService dataManagementService, EnvService envService, DspPolicyService policyService) {
         this.dataManagementService = dataManagementService;
         this.envService = envService;
+        this.policyService = policyService;
     }
 
     /**
@@ -69,12 +63,12 @@ public class DspCatalogService {
      *
      * @return a list of JSON objects representing the DCAT datasets
      */
-    public List<JsonObject> getAllCatalogs(){
+    private List<JsonObject> getAllCatalogs(String partnerId){
         List<? extends DataAsset> allDatasets = dataManagementService.getAll();
         List<JsonObject> catalogs = new ArrayList<>();
 
         for (DataAsset dataset : allDatasets) {
-            catalogs.add(buildDcatDataset(dataset));
+            catalogs.add(buildDcatDataset(dataset, partnerId));
         }
 
         return catalogs;
@@ -86,7 +80,7 @@ public class DspCatalogService {
      * @param dataset the dataset to be converted
      * @return a JSON object representing one DCAT dataset entry
      */
-    public static JsonObject buildDcatDataset(DataAsset dataset) {
+    private JsonObject buildDcatDataset(DataAsset dataset, String partnerId) {
         JsonObjectBuilder distributionBuilder = Json.createObjectBuilder()
                 .add("@type", "dcat:Distribution")
                 .add("dct:format", Json.createObjectBuilder()
@@ -96,7 +90,7 @@ public class DspCatalogService {
         JsonObjectBuilder dcatDatasetBuilder = Json.createObjectBuilder()
                 .add("@id", String.valueOf(dataset.getId()))
                 .add("@type", "dcat:Dataset")
-                .add("odrl:hasPolicy", POLICY)
+                .add("odrl:hasPolicy", policyService.createOfferedPolicy(dataset.getId().toString(), partnerId))
                 .add("dcat:distribution", distributionBuilder)
                 .add("properties", properties);
 
@@ -109,23 +103,18 @@ public class DspCatalogService {
      * @param catalogs the list of catalogs as JSON objects
      * @return a JSON object representing the complete catalog response
      */
-    public JsonObject buildFinalCatalogResponse(List<JsonObject> catalogs) {
+    private JsonObject buildFinalCatalogResponse(List<JsonObject> catalogs) {
         JsonObjectBuilder body = Json.createObjectBuilder()
                 .add("@id", UUID.randomUUID().toString())
                 .add("@type", "dcat:Catalog");
 
-        if (catalogs.size() > 1) {
+        if (catalogs.size() != 1) {
             JsonArrayBuilder datasetArrayBuilder = Json.createArrayBuilder();
             catalogs.forEach(datasetArrayBuilder::add);
             body.add("dcat:dataset", datasetArrayBuilder);
-        }
-        else if (catalogs.size() == 1) {
+        } else {
             body.add("dcat:dataset", catalogs.getFirst());
         }
-        else {
-            body.add("dcat:dataset", Json.createArrayBuilder().build());
-        }
-
         body.add("dcat:service", Json.createObjectBuilder()
                         .add("@id", UUID.randomUUID().toString())
                         .add("@type", "dcat:DataService")
@@ -134,5 +123,15 @@ public class DspCatalogService {
                 .add("dspace:participantId", envService.getBackendId())
                 .add("@context", JsonUtils.FULL_CONTEXT);
         return body.build();
+    }
+
+    /**
+     * Build a catalog response for the given partner.
+     *
+     * @param partnerId the partner
+     * @return the catalog
+     */
+    public JsonObject getFullCatalog(String partnerId) {
+        return buildFinalCatalogResponse(getAllCatalogs(partnerId));
     }
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/NegotiationRecordService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/NegotiationRecordService.java
@@ -49,23 +49,16 @@ public class NegotiationRecordService implements ContractRecordService {
      * @param partnerId - the id under which the consumer refers to himself
      * @param partnerDspUrl - the DSP protocol URL of the consumer partner
      * @param targetAssetId - the id of the asset, which the consumer wants to gain access to
-     * @param permissions - the permissions as proposed by the consumer partner
-     * @param obligations - the obligations as proposed by the consumer partner
-     * @param prohibitions - the prohibitions as proposed by the consumer partner
      * @return - the created NegotiationRecord
      */
     public NegotiationRecord createNegotiationRecord(String consumerPid, String partnerId, String partnerDspUrl,
-                                                     String targetAssetId, String permissions, String obligations,
-                                                     String prohibitions) {
+                                                     String targetAssetId) {
         NegotiationRecord negotiationRecord = new NegotiationRecord();
         negotiationRecord.setConsumerPid(consumerPid);
         negotiationRecord.setPartnerId(partnerId);
         negotiationRecord.setPartnerDspUrl(partnerDspUrl);
         negotiationRecord.setTargetAssetId(targetAssetId);
         negotiationRecord.setState(NegotiationState.REQUESTED);
-        negotiationRecord.setPermissions(permissions);
-        negotiationRecord.setObligations(obligations);
-        negotiationRecord.setProhibitions(prohibitions);
         return repository.save(negotiationRecord);
     }
 

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/policies/EmptyPolicyService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/policies/EmptyPolicyService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024. Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.factoryx.library.connector.embedded.provider.service.policies;
+
+import lombok.extern.slf4j.Slf4j;
+import org.factoryx.library.connector.embedded.provider.interfaces.DspPolicyService;
+import org.factoryx.library.connector.embedded.provider.service.helpers.EnvService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/**
+ * This class purely uses the default implementations of the abstract DspPolicyService, i.e. it will offer
+ * and accept only policies, where permissions, obligations and prohibitions are empty.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "org.factoryx.library.policyservice", havingValue = "empty", matchIfMissing = true)
+public class EmptyPolicyService extends DspPolicyService {
+
+    public EmptyPolicyService(EnvService envService) {
+        super(envService);
+    }
+
+}

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/policies/MvdPolicyService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/policies/MvdPolicyService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024. Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.factoryx.library.connector.embedded.provider.service.policies;
+
+import jakarta.json.Json;
+
+import jakarta.json.JsonValue;
+import lombok.extern.slf4j.Slf4j;
+import org.factoryx.library.connector.embedded.provider.interfaces.DspPolicyService;
+import org.factoryx.library.connector.embedded.provider.service.helpers.EnvService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/**
+ * This class is meant to be used in the current MVD dataspace. It overrides the
+ * createOfferedPolicy method in order to enforce the usage of the standard policy
+ * of that dataspace.
+ *
+ * The validation is simply handled via the default implementation.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "org.factoryx.library.policyservice", havingValue = "mvd")
+public class MvdPolicyService extends DspPolicyService {
+
+    public MvdPolicyService(EnvService envService) {
+        super(envService);
+    }
+
+    @Override
+    public JsonValue getObligation(String assetId, String partnerId) {
+        var obligationsObject = Json.createObjectBuilder();
+        obligationsObject.add("odrl:action", Json.createObjectBuilder().add(ID, "odrl:use").build());
+
+        var constraintsObject = Json.createObjectBuilder();
+        constraintsObject.add("odrl:leftOperand", Json.createObjectBuilder().add(ID, "DataAccess.level").build());
+        constraintsObject.add("odrl:operator", Json.createObjectBuilder().add(ID, "odrl:eq").build());
+        constraintsObject.add("odrl:rightOperand", "processing");
+
+        obligationsObject.add("odrl:constraint", constraintsObject.build());
+        return obligationsObject.build();
+    }
+}


### PR DESCRIPTION
- added abstract DSP policy service and two possible implemtations for generating and validating policies for a given partner and asset-id. 
- additional DSP policy service implementations for other dataspace environments can be added when needed. 
- refactored DspNegotiationService, SendContractAgreedTask and DspCatalogService to use that DSP policy service
- refactored NegotiationRecord, because storing incoming contract terms (permissions, obligations, prohibitions) is no longer needed. 