### PR TITLE
feat: partner properties from dspvalidationservice

### DIFF
--- a/src/main/java/org/factoryx/library/connector/embedded/provider/controller/DspCatalogController.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/controller/DspCatalogController.java
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @Slf4j
 /**
@@ -47,25 +49,26 @@ public class DspCatalogController {
      * Endpoint for requesting the catalog.
      *
      * @param body  the request body as a String
-     * @param token the Authorization header
+     * @param authString the Authorization header
      * @return a ResponseEntity with the JSON response and HTTP status code 200
      */
     @PostMapping("${org.factoryx.library.dspapiprefix:/dsp}/catalog/request")
     public ResponseEntity<String> requestCatalog(@RequestBody(required = false) String body,
-                                                 @RequestHeader(value = "Authorization", required = false) String token) {
+                                                 @RequestHeader(value = "Authorization", required = false) String authString) {
         // Check if body or token is null
-        if (body == null || token == null || token.isEmpty()) {
+        if (body == null || authString == null || authString.isEmpty()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid request: Body and Authorization token are required.");
         }
 
         try {
             log.info("Starting token validation");
-            String partnerId = dspTokenValidationService.validateToken(token);
+            Map<String, String> tokenValidationResult = dspTokenValidationService.validateToken(authString);
+            String partnerId = tokenValidationResult.get(DspTokenValidationService.ReservedKeys.partnerId.toString());
             log.info("Got Result from token validation: {}", partnerId);
             if (partnerId == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
-            JsonObject jsonResponse = dspCatalogService.getFullCatalog(partnerId);
+            JsonObject jsonResponse = dspCatalogService.getFullCatalog(partnerId, tokenValidationResult);
             return ResponseEntity.status(HttpStatus.OK).body(jsonResponse.toString());
 
         } catch (Exception e) {

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/controller/DspNegotiationsController.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/controller/DspNegotiationsController.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -53,12 +54,13 @@ public class DspNegotiationsController {
     public ResponseEntity<byte[]> postNegotiationsNewRequestController(@RequestBody String stringBody,
                                                                        @RequestHeader("Authorization") String authString) {
         try {
-            String partnerId = dspTokenValidationService.validateToken(authString);
+            Map<String, String> tokenValidationResult = dspTokenValidationService.validateToken(authString);
+            String partnerId = tokenValidationResult.get(DspTokenValidationService.ReservedKeys.partnerId.toString());
             if (partnerId == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            ResponseRecord responseRecord = dspNegotiationService.handleNewNegotiation(stringBody, partnerId);
+            ResponseRecord responseRecord = dspNegotiationService.handleNewNegotiation(stringBody, partnerId, tokenValidationResult);
             return ResponseEntity.status(responseRecord.statusCode()).body(responseRecord.responseBody());
         } catch (Exception e) {
             return ResponseEntity.status(401).build();
@@ -79,7 +81,8 @@ public class DspNegotiationsController {
                                                                          @RequestHeader("Authorization") String authString,
                                                                          @PathVariable("providerPid") UUID providerPid) {
         try {
-            String partnerId = dspTokenValidationService.validateToken(authString);
+            Map<String, String> tokenValidationResult = dspTokenValidationService.validateToken(authString);
+            String partnerId = tokenValidationResult.get(DspTokenValidationService.ReservedKeys.partnerId.toString());
             if (partnerId == null) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized request".getBytes());
             }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DataAssetManagementService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DataAssetManagementService.java
@@ -17,6 +17,7 @@
 package org.factoryx.library.connector.embedded.provider.interfaces;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -29,17 +30,39 @@ import java.util.UUID;
 public interface DataAssetManagementService {
 
     /**
-     * Retrieve a single DataAsset entity with the given id
+     * Retrieve a single DataAsset entity with the given id.
+     * Attention: This method should only be used by the DataAccess controller since it is skipping any DCP-related
+     * credential information because it assumes that this has already been checked during the DSP
+     * negotiation and transfer flow.
      *
      * @param id The UUID that specifies a DataAsset
      * @return the DataAsset entity
      */
     DataAsset getById(UUID id);
 
+
     /**
-     * Retrieve a list of all available DataAssets
+     * Retrieve a single DataAsset entity with the given id, if the partnerProperties are sufficient.
      *
+     * The use-case specific implementation of this interface can and should create mechanisms to determine
+     * which asset is visible for which kind of partner properties.
+     *
+     * @param id The UUID that specifies a DataAsset
+     * @param partnerProperties The properties of the partner that were found by the DspValidationService in his
+     *                          verifiable credentials
+     * @return the DataAsset entity
+     */
+    DataAsset getByIdForProperties(UUID id, Map<String, String> partnerProperties);
+
+    /**
+     * Retrieve a list of all available DataAssets (except for those where the partnerProperties are insufficient).
+     *
+     * The use-case specific implementation of this interface can and should create mechanisms to determine
+     * which asset is visible for which kind of partner properties.
+     *
+     * @param partnerProperties The properties of the partner that were found by the DspValidationService in his
+     *                          verifiable credentials
      * @return the list of DataAssets
      */
-    List<? extends DataAsset> getAll();
+    List<? extends DataAsset> getAll(Map<String, String> partnerProperties);
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DspTokenValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DspTokenValidationService.java
@@ -16,6 +16,8 @@
 
 package org.factoryx.library.connector.embedded.provider.interfaces;
 
+import java.util.Map;
+
 public interface DspTokenValidationService {
 
     /**
@@ -24,5 +26,18 @@ public interface DspTokenValidationService {
      * @param token the received token
      * @return the id of the sending partner if successful, else null
      */
-    String validateToken(String token);
+    Map<String, String> validateToken(String token);
+
+    enum ReservedKeys {
+        /**
+         * The id of the partner. In case of DCP based authentication, this should be the partner's did:web id.
+         */
+        partnerId,
+
+        /**
+         * The credentials found during the evaluation of the auth token from the partner. It may contain a single
+         * word describing the found credential. Or it may contain a comma-separated list of credentials.
+         */
+        credentials,
+    }
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspCatalogService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspCatalogService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -63,8 +64,8 @@ public class DspCatalogService {
      *
      * @return a list of JSON objects representing the DCAT datasets
      */
-    private List<JsonObject> getAllCatalogs(String partnerId){
-        List<? extends DataAsset> allDatasets = dataManagementService.getAll();
+    private List<JsonObject> getAllCatalogs(String partnerId, Map<String, String> partnerProperties){
+        List<? extends DataAsset> allDatasets = dataManagementService.getAll(partnerProperties);
         List<JsonObject> catalogs = new ArrayList<>();
 
         for (DataAsset dataset : allDatasets) {
@@ -131,7 +132,7 @@ public class DspCatalogService {
      * @param partnerId the partner
      * @return the catalog
      */
-    public JsonObject getFullCatalog(String partnerId) {
-        return buildFinalCatalogResponse(getAllCatalogs(partnerId));
+    public JsonObject getFullCatalog(String partnerId, Map<String, String> partnerProperties) {
+        return buildFinalCatalogResponse(getAllCatalogs(partnerId, partnerProperties));
     }
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspNegotiationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspNegotiationService.java
@@ -34,6 +34,7 @@ import org.springframework.web.client.RestClient;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
@@ -84,10 +85,8 @@ public class DspNegotiationService {
      * @param partnerId - the id of the requesting party as retrieved from the HTTP auth token
      * @return - a response ACK-body and code 201, if successful
      */
-    public ResponseRecord handleNewNegotiation(String requestBody, String partnerId) {
+    public ResponseRecord handleNewNegotiation(String requestBody, String partnerId, Map<String, String> partnerProperties) {
         JsonObject requestJson = parseAndExpand(requestBody);
-        log.info("RAW REQUEST: {}", prettyPrint(requestBody));
-        log.info("Expanded REQUEST: {}", prettyPrint(requestJson));
         String consumerPid, messageType, partnerDspUrl, targetAssetId;
         JsonObject offer;
         int offerSize;
@@ -121,7 +120,7 @@ public class DspNegotiationService {
 
         try {
             UUID assetId = UUID.fromString(targetAssetId);
-            if (dataManagementService.getById(assetId) == null) {
+            if (dataManagementService.getByIdForProperties(assetId, partnerProperties) == null) {
                 log.warn("Unknown target asset id: {}", targetAssetId);
                 newRecord = negotiationRecordService.updateNegotiationRecordToState(newRecord.getOwnPid(), NegotiationState.TERMINATED);
                 return new ResponseRecord(createErrorResponse(newRecord.getOwnPid().toString(), consumerPid, "ContractNegotiationError",

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspTransferService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/DspTransferService.java
@@ -34,6 +34,7 @@ import org.springframework.web.client.RestClient;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
@@ -85,7 +86,7 @@ public class DspTransferService {
      * @param partnerId - the id of the requesting party as retrieved from the HTTP auth token
      * @return - a response indicating the initiation status of the transfer process
      */
-    public ResponseRecord handleNewTransfer(String requestBody, String partnerId) {
+    public ResponseRecord handleNewTransfer(String requestBody, String partnerId, Map<String, String> partnerProperties) {
         JsonObject requestJson = parseAndExpand(requestBody);
         log.info("RequestJson: {}", requestJson);
         String consumerPid = requestJson.getJsonArray(DSPACE_NAMESPACE + "consumerPid").getJsonObject(0)
@@ -129,7 +130,7 @@ public class DspTransferService {
         }
 
         log.info("Received transfer request for datasetId: {}", datasetId);
-        DataAsset dataset = dataManagementService.getById(datasetId);
+        DataAsset dataset = dataManagementService.getByIdForProperties(datasetId, partnerProperties);
         if (dataset == null) {
             log.warn("Unknown dataset id {} for transfer record", datasetId);
             return abortTransferWithBadRequest(newRecord, "Unknown dataset");
@@ -205,7 +206,6 @@ public class DspTransferService {
      * /dsp/transfers/refresh endpoint.
      *
      * @param refreshToken - the refresh token
-     * @param partnerId - the id of the requesting party as retrieved from the HTTP auth token
      * @return - a response containing the new access token and refresh token
      */
     public ResponseRecord handleRefreshTokenRequest(String refreshToken) {

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_ValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_ValidationService.java
@@ -41,6 +41,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils.parse;
 import static org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils.prettyPrint;
@@ -91,7 +92,7 @@ public class FXv0_1_ValidationService implements DspTokenValidationService {
     }
 
     @Override
-    public String validateToken(String token) {
+    public Map<String, String> validateToken(String token) {
         try {
             log.info("Incoming token: \n{}", token);
             SignedJWT jwt = SignedJWT.parse(token);
@@ -110,7 +111,8 @@ public class FXv0_1_ValidationService implements DspTokenValidationService {
 
             boolean membershipCheck = checkMembershipVerifiablePresentation(selfSignedTokenForPartnerCredentialService, partnerDid);
             if (signatureCheckResult && tokenBasicCheckResult && membershipCheck) {
-                return partnerDid;
+                return Map.of(ReservedKeys.partnerId.toString(), partnerDid,
+                        ReservedKeys.credentials.toString(), "dataspacemember");
             }
             log.warn("Signature check: {}, membership check: {}, basic check: {}", signatureCheckResult, membershipCheck, tokenBasicCheckResult);
             return null;

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mockvalidation/MockValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mockvalidation/MockValidationService.java
@@ -23,6 +23,8 @@ import org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtil
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 @Service
 @Slf4j
 @ConditionalOnProperty(name = "org.factoryx.library.validationservice", havingValue = "mock", matchIfMissing = true)
@@ -35,13 +37,14 @@ public class MockValidationService implements DspTokenValidationService {
     }
 
     @Override
-    public String validateToken(String token) {
+    public Map<String, String> validateToken(String token) {
         try {
             var authJson = JsonUtils.parse(token);
             String clientId = authJson.getString("clientId");
             String audience = authJson.getString("audience");
             if (envService.getOwnDspUrl().equals(audience)) {
-                return clientId;
+                return Map.of(ReservedKeys.partnerId.toString(), clientId,
+                        ReservedKeys.credentials.toString(), "dataspacemember");
             } else {
                 return null;
             }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdValidationService.java
@@ -41,6 +41,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils.parse;
 import static org.factoryx.library.connector.embedded.provider.service.helpers.JsonUtils.prettyPrint;
@@ -91,7 +92,7 @@ public class MvdValidationService implements DspTokenValidationService {
     }
 
     @Override
-    public String validateToken(String token) {
+    public Map<String, String> validateToken(String token) {
         try {
             log.info("Incoming token: \n{}", token);
             SignedJWT jwt = SignedJWT.parse(token);
@@ -110,7 +111,8 @@ public class MvdValidationService implements DspTokenValidationService {
 
             boolean membershipCheck = checkMembershipVerifiablePresentation(selfSignedTokenForPartnerCredentialService, partnerDid);
             if (signatureCheckResult && tokenBasicCheckResult && membershipCheck) {
-                return partnerDid;
+                return Map.of(ReservedKeys.partnerId.toString(), partnerDid,
+                        ReservedKeys.credentials.toString(), "dataspacemember");
             }
             log.warn("Signature check: {}, membership check: {}, basic check: {}", signatureCheckResult, membershipCheck, tokenBasicCheckResult);
             return null;


### PR DESCRIPTION
- changed interface of DspValidationService to return a mapping of partner properties, which contains partnerId, partnercredentials (and could possibly also contain additional metadata regarding that partner)
- changed dsp endpoints so that they are forwarding this data to the respective service to give them the opportunity to evaluate them 
- changed interface of DataAssetManagementService so that these partner properties can be passed on into the concrete implementations of that service 