### PR TITLE
fix: bearer_prefixes

### DIFF
--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_TokenProviderService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_TokenProviderService.java
@@ -127,6 +127,6 @@ public class FXv0_1_TokenProviderService implements DspTokenProviderService {
                 })
                 .body(String.class);
         var stsResponseObject = JsonUtils.parse(stsResponse);
-        return stsResponseObject.getString("access_token");
+        return "Bearer " + stsResponseObject.getString("access_token");
     }
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_ValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_ValidationService.java
@@ -95,6 +95,9 @@ public class FXv0_1_ValidationService implements DspTokenValidationService {
     public Map<String, String> validateToken(String token) {
         try {
             log.info("Incoming token: \n{}", token);
+            if ("Bearer ".equalsIgnoreCase(token.substring(0, 7))) {
+                token = token.substring(7);
+            }
             SignedJWT jwt = SignedJWT.parse(token);
             var claims = jwt.getJWTClaimsSet();
             String partnerDid = claims.getStringClaim("sub");

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mockvalidation/MockValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mockvalidation/MockValidationService.java
@@ -39,6 +39,9 @@ public class MockValidationService implements DspTokenValidationService {
     @Override
     public Map<String, String> validateToken(String token) {
         try {
+            if ("Bearer ".equalsIgnoreCase(token.substring(0, 7))) {
+                token = token.substring(7);
+            }
             var authJson = JsonUtils.parse(token);
             String clientId = authJson.getString("clientId");
             String audience = authJson.getString("audience");

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdTokenProviderService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdTokenProviderService.java
@@ -127,6 +127,6 @@ public class MvdTokenProviderService implements DspTokenProviderService {
                 })
                 .body(String.class);
         var stsResponseObject = JsonUtils.parse(stsResponse);
-        return stsResponseObject.getString("access_token");
+        return "Bearer " + stsResponseObject.getString("access_token");
     }
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdValidationService.java
@@ -95,6 +95,9 @@ public class MvdValidationService implements DspTokenValidationService {
     public Map<String, String> validateToken(String token) {
         try {
             log.info("Incoming token: \n{}", token);
+            if ("Bearer ".equalsIgnoreCase(token.substring(0, 7))) {
+                token = token.substring(7);
+            }
             SignedJWT jwt = SignedJWT.parse(token);
             var claims = jwt.getJWTClaimsSet();
             String partnerDid = claims.getStringClaim("sub");


### PR DESCRIPTION
- newer versions of the EDC now are adding a "Bearer " prefix to DCP Auth Tokens
- fixed DspValidation implementations to adapt to this change