### PR TITLE
fix: return empty maps instead of null when auth failed

### DIFF
--- a/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DspTokenValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/interfaces/DspTokenValidationService.java
@@ -24,7 +24,9 @@ public interface DspTokenValidationService {
      * Validates a token that was received at a DSP protocol endpoint.
      *
      * @param token the received token
-     * @return the id of the sending partner if successful, else null
+     * @return a mapping containing the partnerId (if validated successfully), and optionally the partner's credentials
+     *         and further optionally additional properties of that partner.
+     *
      */
     Map<String, String> validateToken(String token);
 

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_ValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/fxvalidation_v0_1/FXv0_1_ValidationService.java
@@ -118,10 +118,10 @@ public class FXv0_1_ValidationService implements DspTokenValidationService {
                         ReservedKeys.credentials.toString(), "dataspacemember");
             }
             log.warn("Signature check: {}, membership check: {}, basic check: {}", signatureCheckResult, membershipCheck, tokenBasicCheckResult);
-            return null;
+            return Map.of();
         } catch (Exception e) {
             log.error("Failure while validating token {}", token, e);
-            return null;
+            return Map.of();
         }
     }
 

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mockvalidation/MockValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mockvalidation/MockValidationService.java
@@ -49,11 +49,11 @@ public class MockValidationService implements DspTokenValidationService {
                 return Map.of(ReservedKeys.partnerId.toString(), clientId,
                         ReservedKeys.credentials.toString(), "dataspacemember");
             } else {
-                return null;
+                return Map.of();
             }
         } catch (Exception e) {
             log.error("Failure while validating token {}", token, e);
-            return null;
+            return Map.of();
         }
     }
 }

--- a/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdValidationService.java
+++ b/src/main/java/org/factoryx/library/connector/embedded/provider/service/dsp_validation/mvdvalidation/MvdValidationService.java
@@ -118,10 +118,10 @@ public class MvdValidationService implements DspTokenValidationService {
                         ReservedKeys.credentials.toString(), "dataspacemember");
             }
             log.warn("Signature check: {}, membership check: {}, basic check: {}", signatureCheckResult, membershipCheck, tokenBasicCheckResult);
-            return null;
+            return Map.of();
         } catch (Exception e) {
             log.error("Failure while validating token {}", token, e);
-            return null;
+            return Map.of();
         }
     }
 


### PR DESCRIPTION
- DspValidationServices now return an empty map, when validation is unsuccessful
- This prevents NullPointerExceptions in DSP Endpoints